### PR TITLE
support locations by name added

### DIFF
--- a/src/api/openweather/api.ts
+++ b/src/api/openweather/api.ts
@@ -1,7 +1,8 @@
-import { CurrentWeather, MeasurementUnit, ReverseGeocoding } from './types.ts';
+import { CurrentWeather, Geocoding, MeasurementUnit } from './types.ts';
 
 export class Openweathermap {
-  private static apiUrl = 'http://api.openweathermap.org';
+  private static API_URL = 'http://api.openweathermap.org';
+  private static LOCATION_LIMIT = 5;
 
   private apiToken: string;
   private units: MeasurementUnit;
@@ -11,22 +12,56 @@ export class Openweathermap {
     this.units = units;
   }
 
-  async reverseGeocoding(lat: number, lon: number): Promise<ReverseGeocoding[]> {
+  private processErrorResponse(res: Response) {
+    if (res.status === 401) {
+      throw 'invalid api token';
+    }
+    if (res.status === 404) {
+      throw 'invalid api path';
+    }
+    if (res.status === 400) {
+      throw 'invalid api parameters';
+    }
+  }
+
+  private processErrorGeocodingResponse(res: Response): Promise<Geocoding[]> | undefined {
+    if (res.status === 400) {
+      return new Promise((resolve) => resolve([]));
+    }
+    this.processErrorResponse(res);
+  }
+
+  async reverseGeocoding(lat: number, lon: number): Promise<Geocoding[]> {
     const res = await fetch(
-      `${Openweathermap.apiUrl}/geo/1.0/reverse?lat=${lat}&lon=${lon}&units=${this.units}&appid=${this.apiToken}`,
+      `${Openweathermap.API_URL}/geo/1.0/reverse?lat=${lat}&lon=${lon}&limit=${Openweathermap.LOCATION_LIMIT}&units=${this.units}&appid=${this.apiToken}`,
     );
+    if (!res.ok) {
+      const promise = this.processErrorGeocodingResponse(res);
+      if (promise) return promise;
+    }
+    return await res.json();
+  }
+
+  async geocoding(locationName: string): Promise<Geocoding[]> {
+    const res = await fetch(
+      `${Openweathermap.API_URL}/geo/1.0/direct?q=${locationName}&limit=${Openweathermap.LOCATION_LIMIT}&appid=${this.apiToken}`,
+    );
+    if (!res.ok) {
+      const promise = this.processErrorGeocodingResponse(res);
+      if (promise) return promise;
+    }
     return await res.json();
   }
 
   async currentWeather(lat: number, lon: number): Promise<CurrentWeather> {
     const res = await fetch(
-      `${Openweathermap.apiUrl}/data/2.5/weather?lat=${lat}&lon=${lon}&units=${this.units}&appid=${this.apiToken}`,
+      `${Openweathermap.API_URL}/data/2.5/weather?lat=${lat}&lon=${lon}&units=${this.units}&appid=${this.apiToken}`,
     );
     return await res.json();
   }
 
   async locationName(lat: number, lon: number): Promise<string> {
-    const data: ReverseGeocoding[] = await this.reverseGeocoding(lat, lon);
+    const data: Geocoding[] = await this.reverseGeocoding(lat, lon);
     const { name: city, state, country } = data[0];
     return state ? `${city}, ${state}, ${country}` : `${city}, ${country}`;
   }

--- a/src/api/openweather/types.ts
+++ b/src/api/openweather/types.ts
@@ -6,7 +6,7 @@ export type MeasurementUnit = 'standart' | 'metric' | 'imperial';
 /**
  * @see https://openweathermap.org/api/geocoding-api#reverse
  */
-export interface ReverseGeocoding {
+export interface Geocoding {
   name: string;
   local_names: Map<string, string>;
   lat: number;

--- a/src/composers/callbackQueries.ts
+++ b/src/composers/callbackQueries.ts
@@ -19,4 +19,47 @@ composer.callbackQuery(
   }),
 );
 
+composer.callbackQuery(
+  new RegExp(`^select_location#${UUIDRegex.source}$`),
+  processCallbackQuery(async (ctx) => {
+    const locaitonId = ctx.callbackQuery.data.split('#')[1];
+    const suggestedLocation = ctx.session.suggestedLocations.find((location) =>
+      location.id === locaitonId
+    );
+
+    /**
+     * The location isn't found if user again receives
+     * new suggested locations after the first attempt
+     * and tries to pick the previous attempt suggested location
+     */
+    if (!suggestedLocation) {
+      await ctx.answerCallbackQuery({
+        text: `This location can't be selected anymore`,
+        show_alert: true,
+      });
+      return;
+    }
+
+    ctx.session.locations.push(suggestedLocation as Location);
+
+    const chat = ctx.chat;
+    if (chat) {
+      ctx.session.suggestedLocations.forEach(async (location) => {
+        if (suggestedLocation !== location) {
+          await ctx.api.editMessageText(chat.id, location.messageId, '~');
+          return;
+        }
+        await ctx.editMessageText('<i>location selected</i>', { parse_mode: 'HTML' });
+      });
+    }
+
+    ctx.session.suggestedLocations = [];
+
+    await ctx.answerCallbackQuery({ text: 'location has been added' });
+    await ctx.reply(
+      `Location '${suggestedLocation.name}' has been added to your location list. /locations - to see the whole list`,
+    );
+  }),
+);
+
 export { composer as callbackQueryComposer };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -85,3 +85,13 @@ export const createLocationReplyMarkup = (locationId: string): InlineKeyboardMar
     ],
   };
 };
+
+export const createSuggestedLocationReplyMarkup = (locationId: string): InlineKeyboardMarkup => {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'select', callback_data: `select_location#${locationId}` },
+      ],
+    ],
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ bot.use(session({
   initial: (): SessionData => ({
     locations: [],
     notifTimes: [],
+    suggestedLocations: [],
     timeoutId: 0,
   }),
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,10 @@ export interface Location {
   lon: number;
 }
 
+export interface SuggestedLocation extends Location {
+  messageId: number;
+}
+
 export interface Time {
   hours: number;
   minutes: number;
@@ -20,6 +24,7 @@ export interface Time {
 export interface SessionData {
   locations: Location[];
   notifTimes: Time[];
+  suggestedLocations: SuggestedLocation[];
   timeoutId: number;
 }
 


### PR DESCRIPTION
- now locations can be added by location name (in format `city, state, country` |
`city, contry` | `city`)
- when geocordinates or location name are provided, the bot sends
the list of found locations so that users can pick exactly what
they meant. If non of the found locations seems to be right, users might
not select anything and try to search again.
- interface `SuggestedLocation` added to discribe the found location.