### PR TITLE
timezone settings introduced, `TimeApi` updated

### DIFF
--- a/src/api/time/api.ts
+++ b/src/api/time/api.ts
@@ -14,17 +14,37 @@ export class TimeApi {
    *
    * @param lat - latitude
    * @param lon - longitude
-   * @returns `CurrentTime` object if location has been determined by provided
-   * lat and lon
-   * @throws Error if date and time info hasn't been found for provided location
+   * @returns `CurrentDateTime` current date and time have been determined for
+   * provided geocoordinates
+   * @throws Error if date and time info hasn't been found for provided
+   * geocoordinates
    */
-  async currentTime(lat: number, lon: number): Promise<CurrentDateTime> {
+  async currentTimeByCoords(lat: number, lon: number): Promise<CurrentDateTime> {
     const res = await fetch(
       `${TimeApi.API_URL}/Time/current/coordinate?latitude=${lat}&longitude=${lon}`,
     );
     if (res.ok) {
       return await res.json();
     }
-    throw 'failed to determine current time by coordinates';
+    throw 'failed to determine current date and time by coordinates';
+  }
+
+  /**
+   * Determines the current date and time of a timezone by full IANA time zone name
+   *
+   * @param timeZone - full IANA time zone name
+   * @returns `CurrentDateTime` current date and time have been determined for
+   * provided time zone name
+   * @throws Error if current date and time info hasn't been found for provided
+   * time zone name
+   */
+  async currentTimeByTimeZone(timeZone: string): Promise<CurrentDateTime> {
+    const res = await fetch(
+      `${TimeApi.API_URL}/Time/current/zone?timeZone=${timeZone}`,
+    );
+    if (res.ok) {
+      return await res.json();
+    }
+    throw 'failed to determine current date and time by time zone';
   }
 }

--- a/src/composers/commands.ts
+++ b/src/composers/commands.ts
@@ -1,7 +1,12 @@
 import { Composer } from 'https://deno.land/x/grammy@v1.10.1/composer.ts';
 import { CommandContext } from 'https://deno.land/x/grammy@v1.10.1/context.ts';
-import { CurrentDateTime } from '../api/time/types.ts';
-import { calcTimeDiff, createLocationReplyMarkup, findNearestTime, msToTime } from '../helpers.ts';
+import {
+  calcTimeDiff,
+  createLocationReplyMarkup,
+  createSuggestedTimeZonaReplyMarkup,
+  findNearestTime,
+  msToTime,
+} from '../helpers.ts';
 import { openweathermap, timeApi } from '../index.ts';
 import { BotContext, Location, Time } from '../types.ts';
 
@@ -43,6 +48,37 @@ composer.command('add_notif_time', async (ctx) => {
   await ctx.conversation.reenter('addNotifTime');
 });
 
+composer.command('set_time_zone', async (ctx) => {
+  if (!ctx.session.locations.length) {
+    await ctx.reply('you have no saved locations: /add_location');
+    return;
+  }
+
+  await ctx.reply('select location which time zone you would like to use');
+
+  ctx.session.suggestedTimeZones = [];
+
+  ctx.session.locations.forEach(async (location) => {
+    const { time, timeZone } = await timeApi.currentTimeByCoords(location.lat, location.lon);
+    const id = crypto.randomUUID();
+    const messageId = (await ctx.reply(
+      `${location.name}, ${time}, ${timeZone}`,
+      { reply_markup: createSuggestedTimeZonaReplyMarkup(id) },
+    )).message_id;
+
+    ctx.session.suggestedTimeZones.push({ id, messageId, timeZone });
+  });
+});
+
+composer.command('time_zone', async (ctx) => {
+  if (!ctx.session.timeZone) {
+    await ctx.reply(`you haven't set time zone: /set_time_zone`);
+    return;
+  }
+  const data = await timeApi.currentTimeByTimeZone(ctx.session.timeZone);
+  await ctx.reply(`${ctx.session.timeZone}, ${data.time}`);
+});
+
 composer.command('notif_on', async (ctx) => {
   if (ctx.session.timeoutId != 0) {
     await ctx.reply('notificaitons already turned on');
@@ -56,26 +92,21 @@ composer.command('notif_on', async (ctx) => {
     await ctx.reply('you have no added notification times: /add_notif_time');
     return;
   }
+  if (!ctx.session.timeZone) {
+    await ctx.reply(`you haven't set time zone: /set_time_zone`);
+    return;
+  }
 
-  let data: CurrentDateTime;
+  let userDate: Date;
   try {
-    /**
-     * By default, the first added location is retrieved to be
-     * used for determining local time there. Then this time is used for
-     * calculating difference between the local time and the nearest
-     * notification time.
-     *
-     * TODO: let users pick the location from added locations
-     */
-    const location = ctx.session.locations[0];
-    data = await timeApi.currentTime(location.lat, location.lon);
+    const data = await timeApi.currentTimeByTimeZone(ctx.session.timeZone);
+    userDate = new Date(data.dateTime);
   } catch (error) {
     console.error(error);
     await ctx.reply('Unable to turn on notifications :( Something went wrong');
     return;
   }
 
-  const userDate = new Date(data.dateTime);
   const userTime: Time = {
     hours: userDate.getHours(),
     minutes: userDate.getMinutes(),

--- a/src/composers/conversations.ts
+++ b/src/composers/conversations.ts
@@ -7,7 +7,7 @@ import {
 import { Geocoding } from '../api/openweather/types.ts';
 import { createSuggestedLocationReplyMarkup } from '../helpers.ts';
 import { openweathermap } from '../index.ts';
-import { BotContext, BotConversation, SuggestedLocation } from '../types.ts';
+import { BotContext, BotConversation } from '../types.ts';
 
 const composer = new Composer<BotContext>();
 
@@ -75,15 +75,18 @@ const addLocation = async (conversation: BotConversation, ctx: BotContext) => {
     const name = `${geocoding.name}, ${
       geocoding.state ? `${geocoding.state}, ${geocoding.country}` : geocoding.country
     }`;
-    const message = await ctx.reply(name, { reply_markup: createSuggestedLocationReplyMarkup(id) });
-    const suggestedLocation: SuggestedLocation = {
+    const messageId = (await ctx.reply(
+      name,
+      { reply_markup: createSuggestedLocationReplyMarkup(id) },
+    )).message_id;
+
+    ctx.session.suggestedLocations.push({
       id,
       name,
+      messageId,
       lat: geocoding.lat,
       lon: geocoding.lon,
-      messageId: message.message_id,
-    };
-    ctx.session.suggestedLocations.push(suggestedLocation);
+    });
   });
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -95,3 +95,13 @@ export const createSuggestedLocationReplyMarkup = (locationId: string): InlineKe
     ],
   };
 };
+
+export const createSuggestedTimeZonaReplyMarkup = (timeZoneId: string): InlineKeyboardMarkup => {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'select', callback_data: `select_time_zone#${timeZoneId}` },
+      ],
+    ],
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ bot.use(session({
     locations: [],
     notifTimes: [],
     suggestedLocations: [],
+    timeZone: null,
+    suggestedTimeZones: [],
     timeoutId: 0,
   }),
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,18 @@ export interface Time {
   seconds: number;
 }
 
+export interface SuggestedTimeZone {
+  id: string;
+  timeZone: string;
+  messageId: number;
+}
+
 export interface SessionData {
   locations: Location[];
   notifTimes: Time[];
   suggestedLocations: SuggestedLocation[];
+  timeZone: string | null;
+  suggestedTimeZones: SuggestedTimeZone[];
   timeoutId: number;
 }
 


### PR DESCRIPTION
- command `/set_time_zone` added so that users can set time zone from added locations by themselves (the time zone info is used to determine the current user time to turn on notifications by /notif_on command)
- command `/time_zone` added so that users can see their set time zone
- `currentTimeByCoords` and `currentTimeByTimeZone` added instead of single `currentTime` method of `TimeApi`
- `timeZone` and `suggestedTimeZones` have been added to `SessionData` interface